### PR TITLE
use latest node docker and remove unnecessary port exposure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:argon
+FROM node
 
 # Create app directory
 RUN mkdir -p /usr/src/app
@@ -11,5 +11,4 @@ RUN npm install
 # Bundle app source
 COPY . /usr/src/app
 
-EXPOSE 3000
 CMD [ "npm", "run", "docker" ]


### PR DESCRIPTION
With node:argon the npm install runs through but running the container will fail due to some strange installation issues